### PR TITLE
Fix #68

### DIFF
--- a/utilities/printing/print_stl.hpp
+++ b/utilities/printing/print_stl.hpp
@@ -181,10 +181,12 @@ std::ostream& print_tuple(std::ostream& os, T&& rhs, char odelim = '(',
 }
 
 } // namespace detail_
+} // namespace utilities::printing
 
 // Stuff below hwere is just boiler-plate for calling the above functions for
 // ever class in the STL
 
+namespace std{
 /** @brief Makes std::array printable.
  *
  *  @tparam T The type of the element stored in the array.
@@ -558,5 +560,4 @@ template<typename T, typename Alloc>
 std::ostream& operator<<(std::ostream& os, const std::vector<T, Alloc>& v) {
     return utilities::printing::detail_::print_list(os, v);
 }
-
-} // namespace utilities::printing
+} // namespace std

--- a/utilities/printing/print_stl.hpp
+++ b/utilities/printing/print_stl.hpp
@@ -186,7 +186,7 @@ std::ostream& print_tuple(std::ostream& os, T&& rhs, char odelim = '(',
 // Stuff below hwere is just boiler-plate for calling the above functions for
 // ever class in the STL
 
-namespace std{
+namespace std {
 /** @brief Makes std::array printable.
  *
  *  @tparam T The type of the element stored in the array.


### PR DESCRIPTION
This PR is a workaround to fix #68. It turns out the problem is not just with clang. Same unit tests also fail with GCC 12 since the compiler cannot find the overloads. I have a minimal example [here](https://godbolt.org/z/vqEYE8na5).

The discussion on [SO](https://stackoverflow.com/q/73617170/2096243) suggests overloading `<<` for stl containers is not ideal due to possible future violations of ODR (one definition rule), but I guess it is ok for our purposes. If not, we may need to make changes in the whole stack to use `fmt::print` instead of `<<` since `fmt` does not provide `<<` overloads for stl containers.